### PR TITLE
Fix semantic search collection mismatch

### DIFF
--- a/scripts/semantic_search.py
+++ b/scripts/semantic_search.py
@@ -1,24 +1,34 @@
+"""Utilidades de búsqueda semántica en la base de datos de embeddings.
+
+Este módulo se encarga de recuperar los fragmentos de texto más relevantes para un
+campo concreto de la ficha. Durante el desarrollo se duplicó la inicialización de
+la conexión con Chroma y se utilizaron dos nombres de colección distintos
+(`documentos_legales` y `fichas_legales`). Como consecuencia, los embeddings se
+almacenaban en una colección mientras las consultas se realizaban en otra, lo que
+provocaba que no se recuperara ningún fragmento relevante.
+
+Se ha unificado la configuración eliminando las inicializaciones duplicadas y
+asegurando que tanto la generación como la consulta utilicen la misma colección
+(`documentos_legales`).
+"""
+
 import logging
-from openai import OpenAI
-import chromadb
 from typing import List
+
+import chromadb
+from openai import OpenAI
 from dotenv import load_dotenv
 
 load_dotenv()
 
+# Cliente de OpenAI para generar embeddings de las consultas
 client = OpenAI()
+
+# Cliente de Chroma para almacenar y consultar los embeddings
 chroma_client = chromadb.Client()
+
+# Nombre único de la colección utilizada en toda la aplicación
 CHROMA_COLLECTION = "documentos_legales"
-
-from typing import List
-import logging
-from openai import OpenAI
-from chromadb import Client  # o como tengas definido tu cliente Chroma
-
-# Asegúrate de tener estas variables definidas en tu entorno
-client = OpenAI()
-chroma_client = Client()
-CHROMA_COLLECTION = "fichas_legales"
 
 def buscar_chunks_relevantes(campo: str, doc_id: str, top_n: int = 10) -> List[str]:
     """


### PR DESCRIPTION
## Summary
- refactor semantic search utility to remove duplicate configuration and consistently use the `documentos_legales` Chroma collection

## Testing
- `python main.py` *(fails: The api_key client option must be set either by passing api_key to the client or by setting the OPENAI_API_KEY environment variable)*

------
https://chatgpt.com/codex/tasks/task_e_689072f410c88327a858c4fe3a14fe58