### PR TITLE
Fix semantic search collection mismatch and handle OpenAI rate limits

### DIFF
--- a/scripts/generador_campo.py
+++ b/scripts/generador_campo.py
@@ -4,8 +4,10 @@ from openai import OpenAI
 from dotenv import load_dotenv
 from typing import List
 
+from .openai_retry import call_with_retry
+
 load_dotenv()
-client = OpenAI()
+client = OpenAI(max_retries=0)
 
 # Cargar instrucciones globales (una sola vez)
 def cargar_instrucciones(ruta: str = "entradas/intrucciones.json") -> dict:
@@ -76,13 +78,14 @@ Usa exclusivamente los siguientes fragmentos para construir tu respuesta. Si no 
 - Si no hay suficiente información en los fragmentos, devuelve exactamente: ""
 """
 
-        respuesta = client.chat.completions.create(
+        respuesta = call_with_retry(
+            client.chat.completions.create,
             model="gpt-4o",
             messages=[
                 {"role": "system", "content": "Especialista en redacción legal estructurada para automatización de ayudas públicas. No debes inventar contenido bajo ningún concepto."},
                 {"role": "user", "content": user_prompt.strip()}
             ],
-            temperature=0.2
+            temperature=0.2,
         )
 
         return respuesta.choices[0].message.content.strip()

--- a/scripts/generar_campo_debug.py
+++ b/scripts/generar_campo_debug.py
@@ -3,7 +3,7 @@ import os
 import json
 import logging
 from datetime import datetime
-from scripts.embedding_manager import buscar_chunks_relevantes
+from scripts.semantic_search import buscar_chunks_relevantes
 from scripts.generador_ficha import generar_campo_ficha, cargar_instrucciones, cargar_tipos_ayuda
 from dotenv import load_dotenv
 

--- a/scripts/openai_retry.py
+++ b/scripts/openai_retry.py
@@ -1,0 +1,78 @@
+import time
+import random
+import logging
+from typing import Any, Callable
+
+# Errores más comunes en la SDK de OpenAI
+from openai import (
+    RateLimitError,
+    APIError,
+    APIStatusError,
+    APIConnectionError,
+)
+
+
+def call_with_retry(
+    func: Callable[..., Any],
+    *args: Any,
+    max_retries: int = 8,
+    base_delay: float = 2.0,
+    **kwargs: Any,
+) -> Any:
+    """Execute an OpenAI client function with exponential backoff.
+
+    This helper centralises retry behaviour for all OpenAI requests. It honours the
+    ``Retry-After`` header when available and falls back to a jittered exponential
+    backoff. Network and availability errors are also retried.
+
+    Parameters
+    ----------
+    func : Callable
+        Client method to call (e.g. ``client.chat.completions.create``).
+    max_retries : int, optional
+        Maximum number of attempts before giving up, by default ``8``.
+    base_delay : float, optional
+        Initial delay in seconds for the backoff, by default ``2.0``.
+    *args, **kwargs : Any
+        Arguments forwarded to the client function.
+    """
+
+    for intento in range(max_retries):
+        try:
+            return func(*args, **kwargs)
+        except (RateLimitError, APIStatusError, APIError, APIConnectionError) as err:
+            # Determinar el código de estado asociado al error
+            status = getattr(err, "status_code", None)
+            if isinstance(err, RateLimitError):
+                status = 429
+
+            # Errores distintos de rate limit o servidor se relanzan
+            if status not in (429, 500, 502, 503, 504, None) and not isinstance(
+                err, APIConnectionError
+            ):
+                raise
+
+            if intento == max_retries - 1:
+                raise
+
+            # Intentar respetar cabecera Retry-After si está disponible
+            retry_after = None
+            resp = getattr(err, "response", None)
+            if resp is not None:
+                headers = getattr(resp, "headers", {})
+                retry_after = headers.get("Retry-After") or headers.get("retry-after")
+
+            if retry_after is not None:
+                espera = float(retry_after)
+            else:
+                espera_base = base_delay * (2 ** intento)
+                jitter = espera_base * random.random()
+                espera = espera_base + jitter
+
+            logging.warning(
+                f"Rate limit o error de red, reintentando en {espera:.1f}s..."
+            )
+            time.sleep(espera)
+
+    # Si se alcanzan todos los intentos sin éxito, relanzar una excepción genérica
+    raise RuntimeError("Máximo de reintentos alcanzado")

--- a/scripts/semantic_search.py
+++ b/scripts/semantic_search.py
@@ -1,24 +1,36 @@
+"""Utilidades de búsqueda semántica en la base de datos de embeddings.
+
+Este módulo se encarga de recuperar los fragmentos de texto más relevantes para un
+campo concreto de la ficha. Durante el desarrollo se duplicó la inicialización de
+la conexión con Chroma y se utilizaron dos nombres de colección distintos
+(`documentos_legales` y `fichas_legales`). Como consecuencia, los embeddings se
+almacenaban en una colección mientras las consultas se realizaban en otra, lo que
+provocaba que no se recuperara ningún fragmento relevante.
+
+Se ha unificado la configuración eliminando las inicializaciones duplicadas y
+asegurando que tanto la generación como la consulta utilicen la misma colección
+(`documentos_legales`).
+"""
+
 import logging
-from openai import OpenAI
-import chromadb
 from typing import List
+
+import chromadb
+from openai import OpenAI
 from dotenv import load_dotenv
+
+from .openai_retry import call_with_retry
 
 load_dotenv()
 
-client = OpenAI()
+# Cliente de OpenAI para generar embeddings de las consultas
+client = OpenAI(max_retries=0)
+
+# Cliente de Chroma para almacenar y consultar los embeddings
 chroma_client = chromadb.Client()
+
+# Nombre único de la colección utilizada en toda la aplicación
 CHROMA_COLLECTION = "documentos_legales"
-
-from typing import List
-import logging
-from openai import OpenAI
-from chromadb import Client  # o como tengas definido tu cliente Chroma
-
-# Asegúrate de tener estas variables definidas en tu entorno
-client = OpenAI()
-chroma_client = Client()
-CHROMA_COLLECTION = "fichas_legales"
 
 def buscar_chunks_relevantes(campo: str, doc_id: str, top_n: int = 10) -> List[str]:
     """
@@ -31,10 +43,12 @@ def buscar_chunks_relevantes(campo: str, doc_id: str, top_n: int = 10) -> List[s
     """
     try:
         # Embedding de la consulta
-        embedding = client.embeddings.create(
+        embedding_resp = call_with_retry(
+            client.embeddings.create,
             model="text-embedding-3-small",
-            input=campo
-        ).data[0].embedding
+            input=campo,
+        )
+        embedding = embedding_resp.data[0].embedding
 
         # Recuperar colección y buscar
         collection = chroma_client.get_or_create_collection(name=CHROMA_COLLECTION)


### PR DESCRIPTION
## Summary
- refactor semantic search utility to remove duplicate configuration and consistently use the `documentos_legales` Chroma collection
- add reusable `call_with_retry` helper and apply exponential backoff to OpenAI embedding and completion requests
- correct debug helper to import the proper semantic search function
- broaden retry helper to handle more OpenAI API error types and honour `Retry-After` headers while relying solely on custom backoff logic

## Testing
- `python main.py` *(fails: openai.APIConnectionError: Connection error)*

------
https://chatgpt.com/codex/tasks/task_e_689072f410c88327a858c4fe3a14fe58